### PR TITLE
Copy .jvmopts from typelevel/cats

### DIFF
--- a/.jvmopts
+++ b/.jvmopts
@@ -1,0 +1,13 @@
+# copied from https://github.com/typelevel/cats/blob/master/.jvmopts
+
+# see https://weblogs.java.net/blog/kcpeppe/archive/2013/12/11/case-study-jvm-hotspot-flags
+-Dfile.encoding=UTF8
+-Xms1G
+-Xmx6G
+-XX:ReservedCodeCacheSize=250M
+-XX:+TieredCompilation
+-XX:-UseGCOverheadLimit
+# effectively adds GC to Perm space
+-XX:+CMSClassUnloadingEnabled
+# must be enabled for CMSClassUnloadingEnabled to work
+-XX:+UseConcMarkSweepGC


### PR DESCRIPTION
This seems to fix Travis CI build failures like
https://travis-ci.org/fthomas/crjdt/jobs/178691536 which
failed with:

org.scalajs.jsenv.ComJSEnv$ComClosedException: JSCom has been closed