### PR TITLE
introduce document state to JSON conversion

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ cache:
   - "$HOME/.ivy2/cache"
   - "$HOME/.sbt/boot/"
 script:
-- sbt ++$TRAVIS_SCALA_VERSION validate
+- sbt ++$TRAVIS_SCALA_VERSION validateJVM && sbt ++$TRAVIS_SCALA_VERSION validateJS
 after_success:
 - bash <(curl -s https://codecov.io/bash)
 notifications:

--- a/build.sbt
+++ b/build.sbt
@@ -57,6 +57,7 @@ lazy val circe = crossProject
   .settings(
     libraryDependencies ++= Seq(
       "io.circe" %%% "circe-core" % circeVersion,
+      "io.circe" %%% "circe-testing" % circeVersion % "test",
       "org.scalacheck" %%% "scalacheck" % scalaCheckVersion % "test"
     )
   )

--- a/build.sbt
+++ b/build.sbt
@@ -250,5 +250,27 @@ addCommandsAlias("validate",
                    "unidoc"
                  ))
 
+addCommandsAlias("validateJVM",
+                 Seq(
+                   "clean",
+                   "scalafmtTest",
+                   "test:scalafmtTest",
+                   "coverage",
+                   "testJVM",
+                   "coverageReport",
+                   "coverageOff",
+                   "unidoc"
+                 ))
+
+addCommandsAlias("validateJS",
+                 Seq(
+                   "clean",
+                   "scalafmtTest",
+                   "test:scalafmtTest",
+                   "testJS",
+                   "coverageOff",
+                   "unidoc"
+                 ))
+
 addCommandsAlias("syncMavenCentral",
                  allSubprojectsJVM.map(_ + "/bintraySyncMavenCentral"))

--- a/build.sbt
+++ b/build.sbt
@@ -56,7 +56,8 @@ lazy val circe = crossProject
   .jsSettings(commonJsSettings: _*)
   .settings(
     libraryDependencies ++= Seq(
-      "io.circe" %%% "circe-core" % circeVersion
+      "io.circe" %%% "circe-core" % circeVersion,
+      "org.scalacheck" %%% "scalacheck" % scalaCheckVersion % "test"
     )
   )
 

--- a/modules/circe/src/main/scala/eu/timepit/crjdt/circe/NodeToJson.scala
+++ b/modules/circe/src/main/scala/eu/timepit/crjdt/circe/NodeToJson.scala
@@ -1,0 +1,62 @@
+package eu.timepit.crjdt.circe
+
+import eu.timepit.crjdt.core.Node.{ListNode, MapNode, RegNode}
+import eu.timepit.crjdt.core._
+import io.circe.Json
+import scala.annotation.tailrec
+
+private[circe] trait NodeToJson {
+
+  protected def mapToJson(mapNode: MapNode)(
+      implicit rcr: RegNodeConflictResolver): Json =
+    if (mapNode.children.contains(TypeTag.MapT(Key.DocK))) {
+      mapNode.children.collect {
+        case (TypeTag.MapT(Key.DocK), node: MapNode) => mapToJson(node)
+      }.head
+    } else {
+      val fields = mapNode.children.collect {
+        case (TypeTag.MapT(Key.StrK(key)), node: MapNode)
+            if mapNode.getPres(Key.StrK(key)).nonEmpty =>
+          key -> mapToJson(node)
+        case (TypeTag.ListT(Key.StrK(key)), node: ListNode)
+            if mapNode.getPres(Key.StrK(key)).nonEmpty =>
+          key -> listToJson(node)
+        case (TypeTag.RegT(Key.StrK(key)), node: RegNode)
+            if mapNode.getPres(Key.StrK(key)).nonEmpty =>
+          key -> rcr.registerToJson(node)
+      }
+      Json.fromFields(fields)
+    }
+
+  protected def listToJson(listNode: ListNode)(
+      implicit rcr: RegNodeConflictResolver): Json = {
+    @tailrec
+    def loopOrder(listRef: ListRef, keyOrder: Vector[Key]): Vector[Key] =
+      listRef match {
+        case keyRef: KeyRef =>
+          val key = keyRef.toKey
+          val next = listNode.order(keyRef)
+          if (listNode.getPres(key).nonEmpty) {
+            loopOrder(next, keyOrder :+ key)
+          } else {
+            loopOrder(next, keyOrder)
+          }
+        case ListRef.TailR => keyOrder
+      }
+    val keyOrder = loopOrder(ListRef.HeadR, Vector.empty).zipWithIndex.toMap
+    val jsons = new Array[Json](keyOrder.size)
+    listNode.children.foreach {
+      case (TypeTag.MapT(key), node: MapNode)
+          if listNode.getPres(key).nonEmpty =>
+        jsons(keyOrder(key)) = mapToJson(node)
+      case (TypeTag.ListT(key), node: ListNode)
+          if listNode.getPres(key).nonEmpty =>
+        jsons(keyOrder(key)) = listToJson(node)
+      case (TypeTag.RegT(key), node: RegNode)
+          if listNode.getPres(key).nonEmpty =>
+        jsons(keyOrder(key)) = rcr.registerToJson(node)
+    }
+    Json.fromValues(jsons)
+  }
+
+}

--- a/modules/circe/src/main/scala/eu/timepit/crjdt/circe/NodeToJson.scala
+++ b/modules/circe/src/main/scala/eu/timepit/crjdt/circe/NodeToJson.scala
@@ -10,10 +10,11 @@ private[circe] trait NodeToJson {
   protected def mapToJson(mapNode: MapNode)(
       implicit rcr: RegNodeConflictResolver): Json =
     if (mapNode.children.contains(TypeTag.MapT(Key.DocK))) {
-      mapNode.children.collect {
-        case (TypeTag.MapT(Key.DocK), node: MapNode) => mapToJson(node)
-      }.headOption.getOrElse(
-        throw new AssertionError("Root MapNode should contain DocK key only."))
+      mapNode.getChild(TypeTag.MapT(Key.DocK)) match {
+        case node: MapNode => mapToJson(node)
+        case node: ListNode => listToJson(node)
+        case node: RegNode => rcr.registerToJson(node)
+      }
     } else {
       val fields = mapNode.children.collect {
         case (TypeTag.MapT(Key.StrK(key)), node: MapNode)

--- a/modules/circe/src/main/scala/eu/timepit/crjdt/circe/NodeToJson.scala
+++ b/modules/circe/src/main/scala/eu/timepit/crjdt/circe/NodeToJson.scala
@@ -12,7 +12,8 @@ private[circe] trait NodeToJson {
     if (mapNode.children.contains(TypeTag.MapT(Key.DocK))) {
       mapNode.children.collect {
         case (TypeTag.MapT(Key.DocK), node: MapNode) => mapToJson(node)
-      }.head
+      }.headOption.getOrElse(
+        throw new AssertionError("Root MapNode should contain DocK key only."))
     } else {
       val fields = mapNode.children.collect {
         case (TypeTag.MapT(Key.StrK(key)), node: MapNode)

--- a/modules/circe/src/main/scala/eu/timepit/crjdt/circe/RegNodeConflictResolver.scala
+++ b/modules/circe/src/main/scala/eu/timepit/crjdt/circe/RegNodeConflictResolver.scala
@@ -1,0 +1,39 @@
+package eu.timepit.crjdt.circe
+
+import eu.timepit.crjdt.core.{Id, LeafVal, Val}
+import eu.timepit.crjdt.core.Node.RegNode
+import io.circe.Json
+import cats.syntax.order._
+
+trait RegNodeConflictResolver {
+
+  def registerToJson(regNode: RegNode): Json
+
+  protected def valToJson(value: LeafVal): Json = value match {
+    case Val.False => Json.False
+    case Val.True => Json.True
+    case Val.Null => Json.Null
+    case Val.Num(n) => Json.fromBigDecimal(n)
+    case Val.Str(s) => Json.fromString(s)
+  }
+}
+
+object RegNodeConflictResolver {
+
+  implicit val LWW = new RegNodeConflictResolver {
+    override def registerToJson(regNode: RegNode): Json = {
+      val (_, lastVal) = regNode.regValues.max(new Ordering[(Id, LeafVal)] {
+        override def compare(x: (Id, LeafVal), y: (Id, LeafVal)): Int =
+          x._1 compare y._1
+      })
+      valToJson(lastVal)
+    }
+  }
+
+  implicit val PreserveAllAsArray = new RegNodeConflictResolver {
+    override def registerToJson(regNode: RegNode): Json = {
+      val items = regNode.values.map(valToJson)
+      Json.arr(items: _*)
+    }
+  }
+}

--- a/modules/circe/src/main/scala/eu/timepit/crjdt/circe/RegNodeConflictResolver.scala
+++ b/modules/circe/src/main/scala/eu/timepit/crjdt/circe/RegNodeConflictResolver.scala
@@ -20,17 +20,20 @@ trait RegNodeConflictResolver {
 
 object RegNodeConflictResolver {
 
-  implicit val LWW = new RegNodeConflictResolver {
+  implicit object LWW extends RegNodeConflictResolver {
     override def registerToJson(regNode: RegNode): Json = {
       val (_, lastVal) = regNode.regValues.max(new Ordering[(Id, LeafVal)] {
-        override def compare(x: (Id, LeafVal), y: (Id, LeafVal)): Int =
-          x._1 compare y._1
+        override def compare(x: (Id, LeafVal), y: (Id, LeafVal)): Int = {
+          val (xId, _) = x
+          val (yId, _) = y
+          xId compare yId
+        }
       })
       valToJson(lastVal)
     }
   }
 
-  implicit val PreserveAllAsArray = new RegNodeConflictResolver {
+  implicit object PreserveAllAsArray extends RegNodeConflictResolver {
     override def registerToJson(regNode: RegNode): Json = {
       val items = regNode.values.map(valToJson)
       Json.arr(items: _*)

--- a/modules/circe/src/main/scala/eu/timepit/crjdt/circe/syntax/package.scala
+++ b/modules/circe/src/main/scala/eu/timepit/crjdt/circe/syntax/package.scala
@@ -6,7 +6,7 @@ import io.circe.Json
 
 package object syntax extends NodeToJson {
 
-  implicit class PinpNode(node: Node)(implicit rcr: RegNodeConflictResolver) {
+  implicit class PimpNode(node: Node)(implicit rcr: RegNodeConflictResolver) {
     def toJson: Json =
       node match {
         case v: MapNode => mapToJson(v)

--- a/modules/circe/src/main/scala/eu/timepit/crjdt/circe/syntax/package.scala
+++ b/modules/circe/src/main/scala/eu/timepit/crjdt/circe/syntax/package.scala
@@ -1,0 +1,18 @@
+package eu.timepit.crjdt.circe
+
+import eu.timepit.crjdt.core.Node
+import eu.timepit.crjdt.core.Node.{ListNode, MapNode, RegNode}
+import io.circe.Json
+
+package object syntax extends NodeToJson {
+
+  implicit class PinpNode(node: Node)(implicit rcr: RegNodeConflictResolver) {
+    def toJson: Json =
+      node match {
+        case v: MapNode => mapToJson(v)
+        case v: ListNode => listToJson(v)
+        case v: RegNode => rcr.registerToJson(v)
+      }
+  }
+
+}

--- a/modules/circe/src/test/scala/eu/timepit/crjdt/circe/NodeToJsonFigure1Spec.scala
+++ b/modules/circe/src/test/scala/eu/timepit/crjdt/circe/NodeToJsonFigure1Spec.scala
@@ -32,14 +32,14 @@ object NodeToJsonFigure1Spec extends Properties("NodeToJsonFigure1Spec") {
   }
 
   property("toJson with last-writer-wins conflict resolution") = secure {
-    import RegNodeConflictResolver.LWW
+    implicit val resolver = RegNodeConflictResolver.LWW
     p2.document.toJson ?= Json.obj(
       "key" -> Json.fromString("C")
     )
   }
 
   property("toJson with preserve-all-as-array conflict resolution") = secure {
-    import RegNodeConflictResolver.PreserveAllAsArray
+    implicit val resolver = RegNodeConflictResolver.PreserveAllAsArray
     p2.document.toJson ?= Json.obj(
       "key" -> Json.arr(List("B", "C").map(Json.fromString): _*)
     )

--- a/modules/circe/src/test/scala/eu/timepit/crjdt/circe/NodeToJsonFigure1Spec.scala
+++ b/modules/circe/src/test/scala/eu/timepit/crjdt/circe/NodeToJsonFigure1Spec.scala
@@ -1,0 +1,47 @@
+package eu.timepit.crjdt.circe
+
+import eu.timepit.crjdt.core.Replica
+import eu.timepit.crjdt.core.syntax._
+import eu.timepit.crjdt.circe.testUtil.{converged, diverged, merge}
+import eu.timepit.crjdt.circe.syntax._
+import io.circe.Json
+import org.scalacheck.Prop._
+import org.scalacheck.Properties
+
+object NodeToJsonFigure1Spec extends Properties("NodeToJsonFigure1Spec") {
+
+  val p0 = Replica.empty("p").applyCmd(doc.downField("key") := "A")
+  val q0 = merge(Replica.empty("q"), p0)
+
+  property("initial state") = secure {
+    converged(p0, q0)
+  }
+
+  val p1 = p0.applyCmd(doc.downField("key") := "B")
+  val q1 = q0.applyCmd(doc.downField("key") := "C")
+
+  property("divergence") = secure {
+    diverged(p1, q1)
+  }
+
+  val p2 = merge(p1, q1)
+  val q2 = merge(q1, p1)
+
+  property("convergence") = secure {
+    converged(p2, q2)
+  }
+
+  property("toJson with last-writer-wins conflict resolution") = secure {
+    import RegNodeConflictResolver.LWW
+    p2.document.toJson ?= Json.obj(
+      "key" -> Json.fromString("C")
+    )
+  }
+
+  property("toJson with preserve-all-as-array conflict resolution") = secure {
+    import RegNodeConflictResolver.PreserveAllAsArray
+    p2.document.toJson ?= Json.obj(
+      "key" -> Json.arr(List("B", "C").map(Json.fromString): _*)
+    )
+  }
+}

--- a/modules/circe/src/test/scala/eu/timepit/crjdt/circe/NodeToJsonFigure2Spec.scala
+++ b/modules/circe/src/test/scala/eu/timepit/crjdt/circe/NodeToJsonFigure2Spec.scala
@@ -36,7 +36,7 @@ object NodeToJsonFigure2Spec extends Properties("NodeToJsonFigure2Spec") {
   }
 
   property("toJson with last-writer-wins conflict resolution") = secure {
-    import RegNodeConflictResolver.LWW
+    implicit val resolver = RegNodeConflictResolver.LWW
     p2.document.toJson ?= Json.obj(
       "colors" -> Json.obj(
         "red" -> Json.fromString("#ff0000"),
@@ -46,7 +46,7 @@ object NodeToJsonFigure2Spec extends Properties("NodeToJsonFigure2Spec") {
   }
 
   property("toJson with preserve-all-as-array conflict resolution") = secure {
-    import RegNodeConflictResolver.PreserveAllAsArray
+    implicit val resolver = RegNodeConflictResolver.PreserveAllAsArray
     p2.document.toJson ?= Json.obj(
       "colors" -> Json.obj(
         "red" -> Json.arr(Json.fromString("#ff0000")),

--- a/modules/circe/src/test/scala/eu/timepit/crjdt/circe/NodeToJsonFigure2Spec.scala
+++ b/modules/circe/src/test/scala/eu/timepit/crjdt/circe/NodeToJsonFigure2Spec.scala
@@ -1,0 +1,57 @@
+package eu.timepit.crjdt.circe
+
+import eu.timepit.crjdt.core.Replica
+import eu.timepit.crjdt.core.syntax._
+import eu.timepit.crjdt.circe.syntax._
+import eu.timepit.crjdt.circe.testUtil.{converged, diverged, merge}
+import io.circe.Json
+import org.scalacheck.Prop._
+import org.scalacheck.Properties
+
+object NodeToJsonFigure2Spec extends Properties("NodeToJsonFigure2Spec") {
+
+  val colors = doc.downField("colors")
+  val p0 =
+    Replica.empty("p").applyCmd(colors.downField("blue") := "#0000ff")
+  val q0 = merge(Replica.empty("q"), p0)
+
+  property("initial state") = secure {
+    converged(p0, q0)
+  }
+
+  val p1 = p0.applyCmd(colors.downField("red") := "#ff0000")
+  val q1 = q0
+    .applyCmd(colors := `{}`)
+    .applyCmd(colors.downField("green") := "#00ff00")
+
+  property("divergence") = secure {
+    diverged(p1, q1)
+  }
+
+  val p2 = merge(p1, q1)
+  val q2 = merge(q1, p1)
+
+  property("convergence") = secure {
+    converged(p2, q2)
+  }
+
+  property("toJson with last-writer-wins conflict resolution") = secure {
+    import RegNodeConflictResolver.LWW
+    p2.document.toJson ?= Json.obj(
+      "colors" -> Json.obj(
+        "red" -> Json.fromString("#ff0000"),
+        "green" -> Json.fromString("#00ff00")
+      )
+    )
+  }
+
+  property("toJson with preserve-all-as-array conflict resolution") = secure {
+    import RegNodeConflictResolver.PreserveAllAsArray
+    p2.document.toJson ?= Json.obj(
+      "colors" -> Json.obj(
+        "red" -> Json.arr(Json.fromString("#ff0000")),
+        "green" -> Json.arr(Json.fromString("#00ff00"))
+      )
+    )
+  }
+}

--- a/modules/circe/src/test/scala/eu/timepit/crjdt/circe/NodeToJsonFigure3Spec.scala
+++ b/modules/circe/src/test/scala/eu/timepit/crjdt/circe/NodeToJsonFigure3Spec.scala
@@ -40,7 +40,7 @@ object NodeToJsonFigure3Spec extends Properties("NodeToJsonFigure3Spec") {
   }
 
   property("toJson with last-writer-wins conflict resolution") = secure {
-    import RegNodeConflictResolver.LWW
+    implicit val resolver = RegNodeConflictResolver.LWW
     // Figure 3 shows list of the final state is [“eggs”, “ham”, “milk”, “flour”]
     // but ["milk", "flour", "eggs", "ham"] is also valid order.
     q2.document.toJson ?= Json.obj(
@@ -51,7 +51,7 @@ object NodeToJsonFigure3Spec extends Properties("NodeToJsonFigure3Spec") {
   }
 
   property("toJson with preserve-all-as-array conflict resolution") = secure {
-    import RegNodeConflictResolver.PreserveAllAsArray
+    implicit val resolver = RegNodeConflictResolver.PreserveAllAsArray
     q2.document.toJson ?= Json.obj(
       "grocery" -> Json.arr(
         List("milk", "flour", "eggs", "ham").map(v =>

--- a/modules/circe/src/test/scala/eu/timepit/crjdt/circe/NodeToJsonFigure3Spec.scala
+++ b/modules/circe/src/test/scala/eu/timepit/crjdt/circe/NodeToJsonFigure3Spec.scala
@@ -1,0 +1,62 @@
+package eu.timepit.crjdt.circe
+
+import eu.timepit.crjdt.core.Replica
+import eu.timepit.crjdt.core.syntax._
+import eu.timepit.crjdt.circe.syntax._
+import eu.timepit.crjdt.circe.testUtil.{converged, diverged, merge}
+import io.circe.Json
+import org.scalacheck.Prop._
+import org.scalacheck.Properties
+
+object NodeToJsonFigure3Spec extends Properties("NodeToJsonFigure3Spec") {
+
+  val p0 = Replica.empty("p")
+  val q0 = Replica.empty("q")
+
+  property("initial state") = secure {
+    converged(p0, q0)
+  }
+
+  val grocery = doc.downField("grocery")
+
+  val p1 = p0
+    .applyCmd(grocery := `[]`)
+    .applyCmd(grocery.iter.insert("eggs"))
+    .applyCmd(grocery.iter.next.insert("ham"))
+  val q1 = q0
+    .applyCmd(grocery := `[]`)
+    .applyCmd(grocery.iter.insert("milk"))
+    .applyCmd(grocery.iter.next.insert("flour"))
+
+  property("divergence") = secure {
+    diverged(p1, q1)
+  }
+
+  val p2 = merge(p1, q1)
+  val q2 = merge(q1, p1)
+
+  property("convergence") = secure {
+    converged(p2, q2)
+  }
+
+  property("toJson with last-writer-wins conflict resolution") = secure {
+    import RegNodeConflictResolver.LWW
+    // Figure 3 shows list of the final state is [“eggs”, “ham”, “milk”, “flour”]
+    // but ["milk", "flour", "eggs", "ham"] is also valid order.
+    q2.document.toJson ?= Json.obj(
+      "grocery" -> Json.arr(
+        List("milk", "flour", "eggs", "ham").map(Json.fromString): _*
+      )
+    )
+  }
+
+  property("toJson with preserve-all-as-array conflict resolution") = secure {
+    import RegNodeConflictResolver.PreserveAllAsArray
+    q2.document.toJson ?= Json.obj(
+      "grocery" -> Json.arr(
+        List("milk", "flour", "eggs", "ham").map(v =>
+          Json.arr(Json.fromString(v))): _*
+      )
+    )
+  }
+}

--- a/modules/circe/src/test/scala/eu/timepit/crjdt/circe/NodeToJsonFigure3Spec.scala
+++ b/modules/circe/src/test/scala/eu/timepit/crjdt/circe/NodeToJsonFigure3Spec.scala
@@ -41,7 +41,7 @@ object NodeToJsonFigure3Spec extends Properties("NodeToJsonFigure3Spec") {
 
   property("toJson with last-writer-wins conflict resolution") = secure {
     implicit val resolver = RegNodeConflictResolver.LWW
-    // Figure 3 shows list of the final state is [“eggs”, “ham”, “milk”, “flour”]
+    // Figure 3 shows list of the final state is ["eggs", "ham", "milk", "flour"]
     // but ["milk", "flour", "eggs", "ham"] is also valid order.
     q2.document.toJson ?= Json.obj(
       "grocery" -> Json.arr(

--- a/modules/circe/src/test/scala/eu/timepit/crjdt/circe/NodeToJsonFigure4Spec.scala
+++ b/modules/circe/src/test/scala/eu/timepit/crjdt/circe/NodeToJsonFigure4Spec.scala
@@ -37,7 +37,7 @@ object NodeToJsonFigure4Spec extends Properties("NodeToJsonFigure4Spec") {
   }
 
   property("toJson with last-writer-wins conflict resolution") = secure {
-    import RegNodeConflictResolver.LWW
+    implicit val resolver = RegNodeConflictResolver.LWW
     p2.document.toJson ?= Json.obj(
       "todo" -> Json.arr(
         Json.obj(
@@ -48,7 +48,7 @@ object NodeToJsonFigure4Spec extends Properties("NodeToJsonFigure4Spec") {
   }
 
   property("toJson with preserve-all-as-array conflict resolution") = secure {
-    import RegNodeConflictResolver.PreserveAllAsArray
+    implicit val resolver = RegNodeConflictResolver.PreserveAllAsArray
     p2.document.toJson ?= Json.obj(
       "todo" -> Json.arr(
         Json.obj(

--- a/modules/circe/src/test/scala/eu/timepit/crjdt/circe/NodeToJsonFigure4Spec.scala
+++ b/modules/circe/src/test/scala/eu/timepit/crjdt/circe/NodeToJsonFigure4Spec.scala
@@ -1,0 +1,60 @@
+package eu.timepit.crjdt.circe
+
+import eu.timepit.crjdt.core.Replica
+import eu.timepit.crjdt.core.syntax._
+import eu.timepit.crjdt.circe.syntax._
+import eu.timepit.crjdt.circe.testUtil.{converged, diverged, merge}
+import io.circe.Json
+import org.scalacheck.Prop._
+import org.scalacheck.Properties
+
+object NodeToJsonFigure4Spec extends Properties("NodeToJsonFigure4Spec") {
+
+  val todo = doc.downField("todo").iter
+  val cmd = todo.insert(`{}`) `;`
+      (todo.next.downField("title") := "buy milk") `;`
+      (todo.next.downField("done") := false)
+
+  val p0 = Replica.empty("p").applyCmd(cmd)
+  val q0 = merge(Replica.empty("q"), p0)
+
+  property("initial state") = secure {
+    converged(p0, q0)
+  }
+
+  val p1 = p0.applyCmd(todo.next.delete)
+  val q1 = q0.applyCmd(todo.next.downField("done") := true)
+
+  property("divergence") = secure {
+    diverged(p1, q1)
+  }
+
+  val p2 = merge(p1, q1)
+  val q2 = merge(q1, p1)
+
+  property("convergence") = secure {
+    converged(p2, q2)
+  }
+
+  property("toJson with last-writer-wins conflict resolution") = secure {
+    import RegNodeConflictResolver.LWW
+    p2.document.toJson ?= Json.obj(
+      "todo" -> Json.arr(
+        Json.obj(
+          "done" -> Json.True
+        )
+      )
+    )
+  }
+
+  property("toJson with preserve-all-as-array conflict resolution") = secure {
+    import RegNodeConflictResolver.PreserveAllAsArray
+    p2.document.toJson ?= Json.obj(
+      "todo" -> Json.arr(
+        Json.obj(
+          "done" -> Json.arr(Json.True)
+        )
+      )
+    )
+  }
+}

--- a/modules/circe/src/test/scala/eu/timepit/crjdt/circe/NodeToJsonFigure6Spec.scala
+++ b/modules/circe/src/test/scala/eu/timepit/crjdt/circe/NodeToJsonFigure6Spec.scala
@@ -1,0 +1,41 @@
+package eu.timepit.crjdt.circe
+
+import eu.timepit.crjdt.core.Replica
+import eu.timepit.crjdt.core.syntax._
+import eu.timepit.crjdt.circe.syntax._
+import io.circe.Json
+import org.scalacheck.Prop._
+import org.scalacheck.Properties
+
+object NodeToJsonFigure6Spec extends Properties("NodeToJsonFigure6Spec") {
+
+  val list = v("list")
+  val eggs = v("eggs")
+  val cmd = (doc := `{}`) `;`
+      (let(list) = doc.downField("shopping").iter) `;`
+      list.insert("eggs") `;`
+      (let(eggs) = list.next) `;`
+      eggs.insert("milk") `;`
+      list.insert("cheese")
+
+  val document = Replica.empty("").applyCmd(cmd).document
+
+  property("toJson with last-writer-wins conflict resolution") = secure {
+    import RegNodeConflictResolver.LWW
+    document.toJson ?= Json.obj(
+      "shopping" -> Json.arr(
+        List("cheese", "eggs", "milk").map(Json.fromString): _*
+      )
+    )
+  }
+
+  property("toJson with preserve-all-as-array conflict resolution") = secure {
+    import RegNodeConflictResolver.PreserveAllAsArray
+    document.toJson ?= Json.obj(
+      "shopping" -> Json.arr(
+        List("cheese", "eggs", "milk")
+          .map(v => Json.arr(Json.fromString(v))): _*
+      )
+    )
+  }
+}

--- a/modules/circe/src/test/scala/eu/timepit/crjdt/circe/NodeToJsonFigure6Spec.scala
+++ b/modules/circe/src/test/scala/eu/timepit/crjdt/circe/NodeToJsonFigure6Spec.scala
@@ -21,7 +21,7 @@ object NodeToJsonFigure6Spec extends Properties("NodeToJsonFigure6Spec") {
   val document = Replica.empty("").applyCmd(cmd).document
 
   property("toJson with last-writer-wins conflict resolution") = secure {
-    import RegNodeConflictResolver.LWW
+    implicit val resolver = RegNodeConflictResolver.LWW
     document.toJson ?= Json.obj(
       "shopping" -> Json.arr(
         List("cheese", "eggs", "milk").map(Json.fromString): _*
@@ -30,7 +30,7 @@ object NodeToJsonFigure6Spec extends Properties("NodeToJsonFigure6Spec") {
   }
 
   property("toJson with preserve-all-as-array conflict resolution") = secure {
-    import RegNodeConflictResolver.PreserveAllAsArray
+    implicit val resolver = RegNodeConflictResolver.PreserveAllAsArray
     document.toJson ?= Json.obj(
       "shopping" -> Json.arr(
         List("cheese", "eggs", "milk")

--- a/modules/circe/src/test/scala/eu/timepit/crjdt/circe/NodeToJsonSpec.scala
+++ b/modules/circe/src/test/scala/eu/timepit/crjdt/circe/NodeToJsonSpec.scala
@@ -1,5 +1,6 @@
 package eu.timepit.crjdt.circe
 
+import catalysts.Platform
 import eu.timepit.crjdt.core._
 import eu.timepit.crjdt.core.syntax._
 import eu.timepit.crjdt.circe.testUtil._
@@ -15,6 +16,13 @@ import eu.timepit.crjdt.core.Node.MapNode
 object NodeToJsonSpec
     extends Properties("NodeToJsonSpec")
     with ArbitraryInstances {
+
+  // avoid Scala.js test failure at travis CI
+  override protected def maxJsonArraySize: Int = if (Platform.isJs) 5 else 10
+
+  override protected def maxJsonObjectDepth: Int = if (Platform.isJs) 3 else 5
+
+  override protected def maxJsonObjectSize: Int = if (Platform.isJs) 5 else 10
 
   // filter out numbers BigDecimal (and Val.Num) cannot handle
   override def transformJsonNumber(n: JsonNumber): JsonNumber =

--- a/modules/circe/src/test/scala/eu/timepit/crjdt/circe/NodeToJsonSpec.scala
+++ b/modules/circe/src/test/scala/eu/timepit/crjdt/circe/NodeToJsonSpec.scala
@@ -18,11 +18,11 @@ object NodeToJsonSpec
     with ArbitraryInstances {
 
   // avoid Scala.js test failure at travis CI
-  override protected def maxJsonArraySize: Int = if (Platform.isJs) 5 else 10
+  override protected def maxJsonArraySize: Int = if (Platform.isJs) 3 else 10
 
-  override protected def maxJsonObjectDepth: Int = if (Platform.isJs) 3 else 5
+  override protected def maxJsonObjectDepth: Int = if (Platform.isJs) 2 else 5
 
-  override protected def maxJsonObjectSize: Int = if (Platform.isJs) 5 else 10
+  override protected def maxJsonObjectSize: Int = if (Platform.isJs) 3 else 10
 
   // filter out numbers BigDecimal (and Val.Num) cannot handle
   override def transformJsonNumber(n: JsonNumber): JsonNumber =

--- a/modules/circe/src/test/scala/eu/timepit/crjdt/circe/NodeToJsonSpec.scala
+++ b/modules/circe/src/test/scala/eu/timepit/crjdt/circe/NodeToJsonSpec.scala
@@ -1,6 +1,6 @@
 package eu.timepit.crjdt.circe
 
-import eu.timepit.crjdt.core.Replica
+import eu.timepit.crjdt.core._
 import eu.timepit.crjdt.core.syntax._
 import eu.timepit.crjdt.circe.testUtil._
 import io.circe._
@@ -9,6 +9,11 @@ import org.scalacheck.Properties
 import org.scalacheck.Prop._
 import eu.timepit.crjdt.circe.syntax._
 import eu.timepit.crjdt.circe.RegNodeConflictResolver.LWW
+import eu.timepit.crjdt.core.Key.IdK
+import eu.timepit.crjdt.core.ListRef.{HeadR, IdR, TailR}
+import eu.timepit.crjdt.core.Node.{ListNode, RegNode}
+import eu.timepit.crjdt.core.TypeTag.RegT
+import eu.timepit.crjdt.core.Val.Str
 
 object NodeToJsonSpec
     extends Properties("NodeToJsonSpec")
@@ -25,6 +30,30 @@ object NodeToJsonSpec
     val commands = assignObjectFieldsCmds(doc, json.asObject.get)
     val document = Replica.empty("").applyCmds(commands.toList).document
     document.toJson ?= json
+  }
+
+  property("ListNode to JSON") = secure {
+    val groceryList = ListNode(
+      Map(RegT(IdK(Id(2, "q"))) -> RegNode(Map(Id(2, "q") -> Str("milk"))),
+          RegT(IdK(Id(3, "q"))) -> RegNode(Map(Id(3, "q") -> Str("flour"))),
+          RegT(IdK(Id(2, "p"))) -> RegNode(Map(Id(2, "p") -> Str("eggs"))),
+          RegT(IdK(Id(3, "p"))) -> RegNode(Map(Id(3, "p") -> Str("ham")))),
+      Map(IdK(Id(2, "p")) -> Set(Id(2, "p")),
+          IdK(Id(3, "p")) -> Set(Id(3, "p")),
+          IdK(Id(2, "q")) -> Set(Id(2, "q")),
+          IdK(Id(3, "q")) -> Set(Id(3, "q"))),
+      Map(HeadR -> IdR(Id(2, "q")),
+          IdR(Id(2, "q")) -> IdR(Id(3, "q")),
+          IdR(Id(3, "q")) -> IdR(Id(2, "p")),
+          IdR(Id(2, "p")) -> IdR(Id(3, "p")),
+          IdR(Id(3, "p")) -> TailR))
+
+    groceryList.toJson ?= Json.arr(
+      List("milk", "flour", "eggs", "ham").map(Json.fromString): _*)
+  }
+
+  property("RegNode to JSON") = secure {
+    RegNode(Map(Id(1, "p") -> Val.True)).toJson ?= Json.True
   }
 
 }

--- a/modules/circe/src/test/scala/eu/timepit/crjdt/circe/NodeToJsonSpec.scala
+++ b/modules/circe/src/test/scala/eu/timepit/crjdt/circe/NodeToJsonSpec.scala
@@ -1,0 +1,30 @@
+package eu.timepit.crjdt.circe
+
+import eu.timepit.crjdt.core.Replica
+import eu.timepit.crjdt.core.syntax._
+import eu.timepit.crjdt.circe.testUtil._
+import io.circe._
+import io.circe.testing.ArbitraryInstances
+import org.scalacheck.Properties
+import org.scalacheck.Prop._
+import eu.timepit.crjdt.circe.syntax._
+import eu.timepit.crjdt.circe.RegNodeConflictResolver.LWW
+
+object NodeToJsonSpec
+    extends Properties("NodeToJsonSpec")
+    with ArbitraryInstances {
+
+  // filter out numbers BigDecimal (and Val.Num) cannot handle
+  override def transformJsonNumber(n: JsonNumber): JsonNumber =
+    if (n.toDouble == -0.0 || n.toDouble == Double.PositiveInfinity || n.toDouble == Double.NegativeInfinity) {
+      JsonNumber.fromDecimalStringUnsafe("0.0")
+    } else n
+
+  property("toJson") = forAllNoShrink { (obj: JsonObject) =>
+    val json = Json.fromJsonObject(obj)
+    val commands = assignObjectFieldsCmds(doc, json.asObject.get)
+    val document = Replica.empty("").applyCmds(commands.toList).document
+    document.toJson ?= json
+  }
+
+}

--- a/modules/circe/src/test/scala/eu/timepit/crjdt/circe/NodeToJsonSpec.scala
+++ b/modules/circe/src/test/scala/eu/timepit/crjdt/circe/NodeToJsonSpec.scala
@@ -22,7 +22,7 @@ object NodeToJsonSpec
 
   override protected def maxJsonObjectDepth: Int = if (Platform.isJs) 2 else 5
 
-  override protected def maxJsonObjectSize: Int = if (Platform.isJs) 3 else 10
+  override protected def maxJsonObjectSize: Int = if (Platform.isJs) 1 else 10
 
   // filter out numbers BigDecimal (and Val.Num) cannot handle
   override def transformJsonNumber(n: JsonNumber): JsonNumber =

--- a/modules/circe/src/test/scala/eu/timepit/crjdt/circe/testUtil.scala
+++ b/modules/circe/src/test/scala/eu/timepit/crjdt/circe/testUtil.scala
@@ -1,0 +1,26 @@
+package eu.timepit.crjdt.circe
+
+import eu.timepit.crjdt.core.Replica
+import org.scalacheck.Prop
+import org.scalacheck.Prop._
+import scala.util.Random
+
+object testUtil {
+  def converged(a: Replica, b: Replica): Prop =
+    (a.processedOps ?= b.processedOps) && (a.document ?= b.document)
+
+  def converged(a: Replica, b: Replica, c: Replica): Prop =
+    converged(a, b) && converged(b, c)
+
+  def diverged(a: Replica, b: Replica): Prop =
+    (a.processedOps != b.processedOps) && (a.document != b.document)
+
+  def merge(a: Replica, b: Replica): Replica =
+    a.applyRemoteOps(b.generatedOps)
+
+  def randomPermutation[A](xs: Vector[A]): Vector[A] = {
+    val permutations = xs.permutations.toStream.take(12)
+    val index = Random.nextInt(permutations.size)
+    permutations.lift(index).getOrElse(Vector.empty)
+  }
+}


### PR DESCRIPTION
As we talked [earlier](https://twitter.com/fst9000/status/800621798060593152), I introduce `toJson` method to convert document state to JSON.

This implementation is slightly different from the original slide.

1. instead of using object with duplicate key to represent JSON document with conflict, valid JSON object with no duplicate key is used. This avoids reimplementing JSON library and enable to use Circe.

1. conflicted `RegNode` can be resolved into JSON with user-specified `RegNodeConflictResolver`.
In this PR include LLW (last write wins) and PreserveAllAsArray strategy.

LLW can be used for general usage. It chooses latest Replica ID value and does not change JSON structure.

PreserveAllAsArray preserves all conflicted values and represent them as JSON array. It is useful for debug,that is my original motivation, and may be useful for client-side conflict resolution.

This is Figure 1. example.

using LWW strategy
```scala
import eu.timepit.crjdt.circe.syntax._
import RegNodeConflictResolver.LWW
replica.document.toJson
//{
//  "key": "C"
//}
```

using PreserveAllAsArray strategy
```scala
import eu.timepit.crjdt.circe.syntax._
import RegNodeConflictResolver.PreserveAllAsArray
replica.document.toJson
//{
//  "key": ["B", "C"]
//}
```