### PR TITLE
fix MatchError on NodeToJson conversion when list item is deleted

### DIFF
--- a/modules/circe/src/main/scala/eu/timepit/crjdt/circe/NodeToJson.scala
+++ b/modules/circe/src/main/scala/eu/timepit/crjdt/circe/NodeToJson.scala
@@ -47,7 +47,7 @@ private[circe] trait NodeToJson {
       }
     val keyOrder = loopOrder(ListRef.HeadR, Vector.empty).zipWithIndex.toMap
     val jsons = new Array[Json](keyOrder.size)
-    listNode.children.foreach {
+    listNode.children.collect {
       case (TypeTag.MapT(key), node: MapNode)
           if listNode.getPres(key).nonEmpty =>
         jsons(keyOrder(key)) = mapToJson(node)

--- a/modules/circe/src/test/scala/eu/timepit/crjdt/circe/NodeToJsonDeleteSpec.scala
+++ b/modules/circe/src/test/scala/eu/timepit/crjdt/circe/NodeToJsonDeleteSpec.scala
@@ -1,0 +1,26 @@
+package eu.timepit.crjdt.circe
+
+import org.scalacheck.Properties
+import org.scalacheck.Prop._
+import eu.timepit.crjdt.circe.RegNodeConflictResolver.LWW
+import eu.timepit.crjdt.circe.syntax._
+import eu.timepit.crjdt.core.Replica
+import eu.timepit.crjdt.core.syntax._
+import io.circe.Json
+
+object NodeToJsonDeleteSpec extends Properties("NodeToJsonDeleteSpec") {
+
+  // fix bug #19
+  property("delete list items") = secure {
+    val list = doc.downField("list")
+    val p = Replica
+      .empty("p")
+      .applyCmd(list := `[]`)
+      .applyCmd(list.iter.insert("1"))
+      .applyCmd(list.iter.next.insert("2"))
+      .applyCmd(list.iter.next.delete)
+    p.document.toJson ?= Json.obj(
+      "list" -> Json.arr(Json.fromString("2"))
+    )
+  }
+}


### PR DESCRIPTION
fix #19 .

The reported reproducer is added as test case. Existing tests could not detect this bug because `NodeToJsonSpec` did not contain `DELETE` and `NodeToJsonFigure4Spec` did delete an item but the item is present.