### PR TITLE
Add crjdt-haskell as another implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,11 +43,12 @@ GitHub, etc.) to be welcoming environments for everyone.
 
 ## Other implementations
 
-Currently crjdt is the only public implementation of the JSON CRDT described
-in the [paper][paper.abs] by **Kleppmann** and **Beresford**. We will list
-other implementations here as soon as they become available.
+Here are other implementations of the JSON CRDT described in the
+[paper][paper.abs] by **Kleppmann** and **Beresford**.
 
 If you know an implementation that is not listed here, please submit a PR!
+
+- [crjdt-haskell](https://github.com/amarpotghan/crjdt-haskell)
 
 ## Development
 - Format your code with [Scalafmt](http://scalameta.org/scalafmt/).


### PR DESCRIPTION
Happened to come across a Haskell implementation.

Note that I haven't used it and can't vouch for its quality.